### PR TITLE
always pass floats to second outlet of [inlet~]

### DIFF
--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -136,6 +136,13 @@ static void clone_in_all(t_in *x, t_symbol *s, int argc, t_atom *argv)
     x->i_owner->x_phase = phasewas;
 }
 
+static void clone_in_float(t_in *x, t_floatarg f)
+{
+    t_atom a;
+    SETFLOAT(&a, f);
+    clone_in_all(x, &s_list, 1, &a);
+}
+
 static void clone_in_vis(t_in *x, t_floatarg fn, t_floatarg vis)
 {
     int n = fn - x->i_owner->x_startvoice;
@@ -466,6 +473,7 @@ void clone_setup(void)
     class_addmethod(clone_in_class, (t_method)clone_in_vis, gensym("vis"),
         A_FLOAT, A_FLOAT, 0);
     class_addlist(clone_in_class, (t_method)clone_in_list);
+    class_addfloat(clone_in_class, (t_method)clone_in_float);
 
     clone_out_class = class_new(gensym("clone-outlet"), 0, 0,
         sizeof(t_in), CLASS_PD, 0);

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -119,7 +119,10 @@ void vinlet_status(t_vinlet *x)
       return;
 
     x->x_status_last = count;
-    outlet_float(x->x_status, count);
+    t_atom a;
+    SETFLOAT(&a, count);
+    /* prefix in case we add more info later */
+    outlet_anything(x->x_status, gensym("signals"), 1, &a);
 }
 
 t_int *vinlet_perform(t_int *w)

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -51,48 +51,41 @@ static void *vinlet_new(t_symbol *s)
     x->x_inlet = canvas_addinlet(x->x_canvas, &x->x_obj.ob_pd, 0);
     x->x_bufsize = 0;
     x->x_buf = 0;
-    x->x_anyoutlet = 0;
+    x->x_anyoutlet = outlet_new(&x->x_obj, 0);
     x->x_clock = 0;
     x->x_status = 0;
     x->x_status_last = -1;
-    outlet_new(&x->x_obj, 0);
     return (x);
-}
-
-static t_outlet * vinlet_outlet(t_vinlet *x) {
-    if (x->x_anyoutlet)
-        return x->x_anyoutlet;
-    return x->x_obj.ob_outlet;
 }
 
 static void vinlet_bang(t_vinlet *x)
 {
-    outlet_bang(vinlet_outlet(x));
+    outlet_bang(x->x_anyoutlet);
 }
 
 static void vinlet_pointer(t_vinlet *x, t_gpointer *gp)
 {
-    outlet_pointer(vinlet_outlet(x), gp);
+    outlet_pointer(x->x_anyoutlet, gp);
 }
 
 static void vinlet_float(t_vinlet *x, t_float f)
 {
-    outlet_float(vinlet_outlet(x), f);
+    outlet_float(x->x_anyoutlet, f);
 }
 
 static void vinlet_symbol(t_vinlet *x, t_symbol *s)
 {
-    outlet_symbol(vinlet_outlet(x), s);
+    outlet_symbol(x->x_anyoutlet, s);
 }
 
 static void vinlet_list(t_vinlet *x, t_symbol *s, int argc, t_atom *argv)
 {
-    outlet_list(vinlet_outlet(x), s, argc, argv);
+    outlet_list(x->x_anyoutlet, s, argc, argv);
 }
 
 static void vinlet_anything(t_vinlet *x, t_symbol *s, int argc, t_atom *argv)
 {
-    outlet_anything(vinlet_outlet(x), s, argc, argv);
+    outlet_anything(x->x_anyoutlet, s, argc, argv);
 }
 
 static void vinlet_free(t_vinlet *x)

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -131,7 +131,11 @@ static void inlet_float(t_inlet *x, t_float f)
     if (x->i_symfrom == &s_float)
         pd_vmess(x->i_dest, x->i_symto, "f", (t_floatarg)f);
     else if (x->i_symfrom == &s_signal)
+    {
         x->i_un.iu_floatsignalvalue = f;
+        if (x->i_generic)
+            pd_float(x->i_dest, f);
+    }
     else if (!x->i_symfrom || x->i_generic)
         pd_float(x->i_dest, f);
     else if (x->i_symfrom == &s_list)


### PR DESCRIPTION
suggested by @umlaeute in https://github.com/pure-data/pure-data/pull/363#issuecomment-390030484

this enables users to interpret float messages to [inlet~] (like some externals do). 

note that float to signal promotion is preserved! you need to manually silence the output in case there is no connection. this can be easily done with the 3rd outlet.

also prefix the number of signal connections just in case we want to add more info later.