### PR TITLE
set/change signal scalar value of inlet~ via creation argument or inlet.

### DIFF
--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -759,6 +759,13 @@ t_float *obj_findsignalscalar(t_object *x, int m)
 
 /* and these are only used in g_io.c... */
 
+t_float * inlet_floatsignalpointer(t_inlet *x)
+{
+    if (x->i_symfrom != &s_signal)
+        bug("inlet_floatsignalpointer");
+    return &x->i_un.iu_floatsignalvalue;
+}
+
 int inlet_getsignalindex(t_inlet *x)
 {
     int n = 0;


### PR DESCRIPTION
this helps to emulate the behaviour of objects like [osc~ 440] with abstractions. actually, it can already be achieved with the additional outlets, but this way is much easier (and more efficient).

ported from https://github.com/pure-data/pure-data/pull/363